### PR TITLE
feat(archetypes): function×domain grid + deep-memory pooling

### DIFF
--- a/captain_claw/flight_deck/archetype_compose.py
+++ b/captain_claw/flight_deck/archetype_compose.py
@@ -1,0 +1,210 @@
+"""Two-axis (function × domain) archetype composition — PROTOTYPE, flag-gated.
+
+A *grid* agent is a pair ``function.domain`` (e.g. ``reviewer.legal``). Instead
+of storing F×M flat leaf archetypes, we keep two small base registries —
+``instructions/functions.json`` (role / SOP / base tools / cognitive_mode /
+recall_mode) and ``instructions/domains.json`` (instruction overlay / extra
+tools / tier_floor / recall_override) — and compose a leaf on the fly at spawn
+time. Editing one function updates every domain's variant of it, and editing one
+domain updates every function's variant: a "living" grid on both axes, whereas a
+flattened leaf is only living along whichever single id it was stored under.
+
+The composed dict has the SAME shape the base archetype registry yields, so
+every downstream consumer (``server._resolve_archetype``'s fold-in, dubina's
+``spawn_archetype_agent``) treats it identically — no downstream changes.
+
+Gated by the ``FD_ARCHETYPE_GRID`` env flag. When off (the default), or when an
+id is not a resolvable pair, callers fall back to the existing single-id
+archetype lookup — so this is purely additive and non-breaking. Base archetype
+ids never contain a dot, so a dotted id is unambiguously a grid selector.
+
+PROTOTYPE SCOPE / follow-ups (not in this module):
+- Composition reads the BASE function/domain files only; per-user function or
+  domain overlays (the equivalent of ``user_archetypes`` shadowing a base id)
+  are future work.
+- The composed dict carries ``recall_mode`` and ``memory_tags`` for the
+  deep-memory pooling design, but WRITING those tags into deep memory (threading
+  them into ``DeepMemoryIndex.add`` / ``search``) is a separate wiring step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from captain_claw.logging import get_logger
+
+log = get_logger(__name__)
+
+_INSTR = Path(__file__).parent.parent / "instructions"
+_FUNCTIONS_FILE = _INSTR / "functions.json"
+_DOMAINS_FILE = _INSTR / "domains.json"
+
+_GRID_FLAG = "FD_ARCHETYPE_GRID"
+
+# Tier capability ladder, low → high. A domain's ``tier_floor`` can only RAISE a
+# function's tier, never lower it. Tiers outside this ladder (coding / vision —
+# specialist, not strictly "higher") are treated as no-floor.
+_TIER_ORDER = ["micro", "fast", "balanced", "longctx", "reason"]
+
+
+def grid_enabled() -> bool:
+    """True when the function×domain grid is switched on via ``FD_ARCHETYPE_GRID``."""
+    return os.environ.get(_GRID_FLAG, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _load(path: Path, key: str) -> dict[str, dict]:
+    """Load a registry file into an ``id → entry`` map.
+
+    Best-effort: a missing or invalid file yields an empty map (logged for the
+    invalid case) so a broken grid file can never break the normal spawn path.
+    """
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError:
+        return {}
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Invalid grid registry; ignoring", file=str(path), error=str(exc))
+        return {}
+    out: dict[str, dict] = {}
+    for entry in data.get(key, []):
+        eid = str(entry.get("id") or "").strip()
+        if eid:
+            out[eid] = entry
+    return out
+
+
+def load_functions() -> dict[str, dict]:
+    """The function axis, keyed by id. Empty when the file is absent/invalid."""
+    return _load(_FUNCTIONS_FILE, "functions")
+
+
+def load_domains() -> dict[str, dict]:
+    """The domain axis, keyed by id. Empty when the file is absent/invalid."""
+    return _load(_DOMAINS_FILE, "domains")
+
+
+def parse_pair(aid: str) -> tuple[str, str | None]:
+    """``"reviewer.legal"`` → ``("reviewer", "legal")``; a plain id → ``(aid, None)``.
+
+    Splits on the FIRST dot only (a function id may not contain a dot; a domain
+    id may). Any ``@tier`` suffix has already been stripped by the caller, which
+    partitions on ``@`` before resolving the id.
+    """
+    aid = (aid or "").strip()
+    if "." not in aid:
+        return aid, None
+    fid, _, did = aid.partition(".")
+    fid, did = fid.strip(), did.strip()
+    if not fid or not did:
+        return aid, None
+    return fid, did
+
+
+def _max_tier(fn_tier: str | None, dom_floor: str | None) -> str:
+    """Return the function's tier raised to the domain's floor when the floor is
+    higher on the capability ladder. Unknown tiers → no raise (return fn_tier)."""
+    fn_tier = (fn_tier or "balanced").strip()
+    if not dom_floor:
+        return fn_tier
+    try:
+        higher = _TIER_ORDER.index(fn_tier) >= _TIER_ORDER.index(str(dom_floor).strip())
+    except ValueError:
+        return fn_tier
+    return fn_tier if higher else str(dom_floor).strip()
+
+
+def compose_archetype(fn: dict, dm: dict) -> dict:
+    """Compose a function entry and a domain entry into a spawn-ready archetype.
+
+    Merge rules:
+      - ``fleet_instructions`` — function (role + SOP), then the domain overlay
+        appended after a blank line.
+      - ``tools`` — union of the function's tools and the domain's ``tools_add``.
+      - ``tier`` — the function's tier, raised to the domain's ``tier_floor`` if
+        that floor is higher (:func:`_max_tier`).
+      - ``cognitive_mode`` — the function's (how it thinks).
+      - ``recall_mode`` — the domain's ``recall_override`` if set, else the
+        function's (drives deep-memory recall breadth: pool | domain | self).
+      - ``memory_tags`` — ``["agent:<fn>", "domain:<dm>"]`` for deep-memory
+        pooling (write both; recall filters on them).
+    """
+    fid, did = str(fn["id"]), str(dm["id"])
+    label = str(dm.get("label") or did)
+    role = str(fn.get("role") or fid)
+    fn_instr = str(fn.get("fleet_instructions") or "").rstrip()
+    overlay = str(dm.get("overlay") or "").strip()
+    tools = sorted(set(fn.get("tools") or []) | set(dm.get("tools_add") or []))
+    keywords = sorted(set(fn.get("keywords") or []) | set(dm.get("keywords") or []))
+    return {
+        "id": f"{fid}.{did}",
+        "role": f"{label} {role}",
+        "family": label,
+        "description": str(fn.get("description") or role),
+        "cognitive_mode": str(fn.get("cognitive_mode") or "neutra"),
+        "tier": _max_tier(fn.get("tier"), dm.get("tier_floor")),
+        "tools": tools,
+        "keywords": keywords,
+        "reliability_seed": fn.get("reliability_seed", 0.7),
+        "runtime": str(fn.get("runtime") or ""),
+        "fleet_instructions": (fn_instr + ("\n\n" + overlay if overlay else "")).strip(),
+        # ── grid extensions (consumed by the deep-memory pooling design) ──
+        "recall_mode": str(dm.get("recall_override") or fn.get("recall_mode") or "pool"),
+        "memory_tags": [f"agent:{fid}", f"domain:{did}"],
+        "composed": True,
+        "source": "grid",
+    }
+
+
+def recall_filter(recall_mode: str, memory_tags: list[str] | None) -> str:
+    """Build a Typesense ``filter_by`` fragment for an agent's recall breadth.
+
+    - ``pool`` (or unknown/empty) → ``""`` — read the whole owner pool, no tag
+      narrowing (the safe default; the owner scope is ANDed on server-side).
+    - ``domain`` → restrict to the agent's ``domain:<x>`` tag.
+    - ``self`` → restrict to the agent's own ``agent:<x>`` tag.
+
+    Degrades to ``""`` (pool) when the mode needs a tag the agent doesn't carry.
+
+    NOTE: a ``domain``/``self`` filter also excludes pool rows that carry *no*
+    tags (e.g. auto-indexed VFS files). That is intended for a specialist that
+    wants high-signal recall; the follow-up to also see shared/general context is
+    to stamp a ``domain:general`` sentinel on untagged writes and OR it in here.
+    """
+    mode = (recall_mode or "pool").strip().lower()
+    if mode not in ("domain", "self"):
+        return ""
+    prefix = "domain:" if mode == "domain" else "agent:"
+    tag = next((t for t in (memory_tags or []) if t.startswith(prefix)), "")
+    return f"tags:=`{tag}`" if tag else ""
+
+
+def resolve_pair(aid: str) -> dict | None:
+    """Resolve a ``function.domain`` id into a composed archetype, or ``None``.
+
+    Returns ``None`` — deferring to the normal single-id lookup — when the grid
+    is disabled, the id is not a pair, or either axis is unknown. Never raises:
+    a bad grid file must degrade gracefully to base behaviour.
+    """
+    if not grid_enabled():
+        return None
+    fid, did = parse_pair(aid)
+    if did is None:
+        return None
+    try:
+        fn = load_functions().get(fid)
+        dm = load_domains().get(did)
+    except Exception as exc:  # defensive: file races, unexpected shapes
+        log.warning("Grid registry load failed", pair=aid, error=str(exc))
+        return None
+    if not fn or not dm:
+        return None
+    try:
+        composed = compose_archetype(fn, dm)
+    except Exception as exc:
+        log.warning("Archetype composition failed", pair=aid, error=str(exc))
+        return None
+    log.info("Composed grid archetype", pair=aid, tier=composed["tier"],
+             recall_mode=composed["recall_mode"], tags=composed["memory_tags"])
+    return composed

--- a/captain_claw/flight_deck/archetype_compose.py
+++ b/captain_claw/flight_deck/archetype_compose.py
@@ -43,6 +43,12 @@ _DOMAINS_FILE = _INSTR / "domains.json"
 
 _GRID_FLAG = "FD_ARCHETYPE_GRID"
 
+# Sentinel domain tag marking shared/cross-domain content — content that every
+# domain specialist should see regardless of its own domain (e.g. a non-grid
+# agent's cross-cutting output). Documents (source != "agent") are shared without
+# needing this tag; the ``domain`` recall filter OR-s both in.
+GENERAL_DOMAIN_TAG = "domain:general"
+
 # Tier capability ladder, low → high. A domain's ``tier_floor`` can only RAISE a
 # function's tier, never lower it. Tiers outside this ladder (coding / vision —
 # specialist, not strictly "higher") are treated as no-floor.
@@ -162,22 +168,29 @@ def recall_filter(recall_mode: str, memory_tags: list[str] | None) -> str:
 
     - ``pool`` (or unknown/empty) → ``""`` — read the whole owner pool, no tag
       narrowing (the safe default; the owner scope is ANDed on server-side).
-    - ``domain`` → restrict to the agent's ``domain:<x>`` tag.
-    - ``self`` → restrict to the agent's own ``agent:<x>`` tag.
+    - ``domain`` → the agent's own ``domain:<x>`` rows, PLUS shared context so a
+      specialist still sees the user's documents and cross-cutting notes:
+      ``(tags:=domain:<x> || tags:=domain:general || source:!=agent)``. Documents
+      (``source`` "vfs"/"manual", never "agent") come in via the source clause;
+      shared *agent* output comes in via the ``domain:general`` sentinel; only
+      *other* domains' agent-specific memories are excluded.
+    - ``self`` → strictly the agent's own ``agent:<x>`` tag (the uncontaminated
+      mode — no documents, no sharing).
 
     Degrades to ``""`` (pool) when the mode needs a tag the agent doesn't carry.
-
-    NOTE: a ``domain``/``self`` filter also excludes pool rows that carry *no*
-    tags (e.g. auto-indexed VFS files). That is intended for a specialist that
-    wants high-signal recall; the follow-up to also see shared/general context is
-    to stamp a ``domain:general`` sentinel on untagged writes and OR it in here.
     """
     mode = (recall_mode or "pool").strip().lower()
-    if mode not in ("domain", "self"):
+    if mode == "self":
+        tag = next((t for t in (memory_tags or []) if t.startswith("agent:")), "")
+        return f"tags:=`{tag}`" if tag else ""
+    if mode != "domain":
         return ""
-    prefix = "domain:" if mode == "domain" else "agent:"
-    tag = next((t for t in (memory_tags or []) if t.startswith(prefix)), "")
-    return f"tags:=`{tag}`" if tag else ""
+    tag = next((t for t in (memory_tags or []) if t.startswith("domain:")), "")
+    if not tag:
+        return ""
+    return (
+        f"(tags:=`{tag}` || tags:=`{GENERAL_DOMAIN_TAG}` || source:!=`agent`)"
+    )
 
 
 def resolve_pair(aid: str) -> dict | None:

--- a/captain_claw/flight_deck/deep_memory_routes.py
+++ b/captain_claw/flight_deck/deep_memory_routes.py
@@ -385,8 +385,17 @@ async def agent_index(body: AgentIndexBody, request: Request) -> dict[str, Any]:
     import hashlib
 
     # Grid agents stamp their axis tags (agent:<fn>, domain:<dm>) so a user's pool
-    # is sliceable by agent/domain on read; a non-grid agent writes untagged.
+    # is sliceable by agent/domain on read. When the grid is on, an agent with no
+    # domain of its own (a non-grid / cross-cutting agent) is marked domain:general
+    # so its output stays visible to every domain specialist's narrowed recall.
+    from captain_claw.flight_deck.archetype_compose import (
+        GENERAL_DOMAIN_TAG,
+        grid_enabled,
+    )
+
     tags, _recall = _agent_grid(request)
+    if grid_enabled() and not any(str(t).startswith("domain:") for t in tags):
+        tags = [*tags, GENERAL_DOMAIN_TAG]
     digest = hashlib.sha256(body.text.encode()).hexdigest()
     reference = body.reference or f"agent:{digest[:16]}"
     index.delete_by_reference(reference, owner_id=owner)

--- a/captain_claw/flight_deck/deep_memory_routes.py
+++ b/captain_claw/flight_deck/deep_memory_routes.py
@@ -88,6 +88,29 @@ def _agent_owner(request: Request) -> str:
     return owner
 
 
+def _agent_grid(request: Request) -> tuple[list[str], str]:
+    """The calling agent's deep-memory grid config — (memory_tags, recall_mode) —
+    resolved from FD's own records the same way :func:`_agent_owner` resolves the
+    owner (web_auth token first, then source port). Returns ``([], "")`` for a
+    non-grid agent, so the proxy writes untagged and reads the whole owner pool
+    exactly as before. Purely a within-tenant refinement: tags never widen access
+    past the server-resolved owner, so this never needs the identity gate.
+    """
+    from captain_claw.flight_deck.server import (
+        _resolve_agent_grid,
+        _resolve_agent_grid_by_auth,
+    )
+
+    token = request.headers.get("X-Agent-Auth", "")
+    if token:
+        return _resolve_agent_grid_by_auth(token)
+    port = getattr(getattr(request, "client", None), "port", 0) or 0
+    try:
+        return _resolve_agent_grid(int(port))
+    except Exception:
+        return [], ""
+
+
 # ---------------------------------------------------------------------------
 # Bodies
 # ---------------------------------------------------------------------------
@@ -333,9 +356,19 @@ def _require_connection() -> None:
 async def agent_search(body: AgentSearchBody, request: Request) -> dict[str, Any]:
     owner = _agent_owner(request)
     _require_connection()
+    # Narrow recall by the agent's grid recall_mode (pool → no narrowing). ANDed
+    # onto any caller-supplied filter; the owner scope is ANDed again inside the
+    # index, so this can only narrow within the tenant, never widen past it.
+    from captain_claw.flight_deck.archetype_compose import recall_filter
+
+    tags, recall = _agent_grid(request)
+    rf = recall_filter(recall, tags)
+    combined = (body.filter_by or "").strip()
+    if rf:
+        combined = f"({combined}) && {rf}" if combined else rf
     return {
         "results": svc.search(
-            owner, body.query, max_results=body.max_results, filter_by=body.filter_by
+            owner, body.query, max_results=body.max_results, filter_by=combined
         )
     }
 
@@ -351,6 +384,9 @@ async def agent_index(body: AgentIndexBody, request: Request) -> dict[str, Any]:
         raise HTTPException(400, "text is required")
     import hashlib
 
+    # Grid agents stamp their axis tags (agent:<fn>, domain:<dm>) so a user's pool
+    # is sliceable by agent/domain on read; a non-grid agent writes untagged.
+    tags, _recall = _agent_grid(request)
     digest = hashlib.sha256(body.text.encode()).hexdigest()
     reference = body.reference or f"agent:{digest[:16]}"
     index.delete_by_reference(reference, owner_id=owner)
@@ -362,6 +398,7 @@ async def agent_index(body: AgentIndexBody, request: Request) -> dict[str, Any]:
         path=reference,
         owner_id=owner,
         content_hash=digest,
+        tags=tags or None,
         summarize=body.summarize,
     )
     return {"ok": True, "reference": reference, "chunks": chunks}

--- a/captain_claw/flight_deck/dubina_agents.py
+++ b/captain_claw/flight_deck/dubina_agents.py
@@ -150,6 +150,11 @@ def _build_agent_config(archetype: dict, tier: str, tcfg: dict, name_suffix: str
         env_vars=list(env_vars or []),
         web_enabled=True, web_port=0,
         workspace_path=workspace_path or "",
+        # Carry deep-memory grid config from a composed function×domain leaf so the
+        # spawned agent's deep-memory writes/reads are tagged/narrowed. Empty for a
+        # normal archetype (pools by owner, unchanged).
+        grid_memory_tags=list(archetype.get("memory_tags") or []),
+        grid_recall_mode=str(archetype.get("recall_mode") or ""),
     )
     model = tcfg.get("model")
     if model:

--- a/captain_claw/flight_deck/server.py
+++ b/captain_claw/flight_deck/server.py
@@ -754,7 +754,13 @@ async def lifespan(app: FastAPI):
 
         async def _flow_load_archetype(payload: dict, aid: str):
             from captain_claw.flight_deck.archetypes import merged_archetypes
+            from captain_claw.flight_deck.archetype_compose import resolve_pair
             from captain_claw.flight_deck.auth import get_db
+            # Flag-gated function×domain grid: `on archetype:reviewer.legal` composes
+            # a leaf whose `fleet_instructions` the spawned dubina agent then uses.
+            composed = resolve_pair(aid)
+            if composed is not None:
+                return composed
             uid = _flow_owner_id(payload) or None
             for a in await merged_archetypes(get_db(), uid):
                 if a.get("id") == aid:
@@ -1187,6 +1193,15 @@ class AgentConfig(BaseModel):
     # (mirroring dubina's `_build_agent_config`). Explicit fields the caller already
     # set win over the archetype; an unknown id is a non-fatal no-op.
     archetype: str = ""
+    # Deep-memory grid config, populated when `archetype` resolves to a composed
+    # function×domain leaf (see archetype_compose). `grid_memory_tags` are stamped
+    # onto the agent's deep-memory writes; `grid_recall_mode` (pool | domain | self)
+    # narrows its deep-memory reads. Empty for a normal archetype — the agent then
+    # pools by owner with no tag filter, exactly as before. Carried into the
+    # process registry / Docker labels at spawn so the FD deep-memory proxy can
+    # resolve them without the agent asserting anything.
+    grid_memory_tags: list[str] = Field(default_factory=list)
+    grid_recall_mode: str = ""
     # Optional per-session selectable model list (config.model.allowed). Used by
     # the free-OpenRouter "Freebie" spawn so all free models are available to
     # switch between at runtime, with `model` as the default.
@@ -1307,16 +1322,23 @@ async def _resolve_archetype(config: AgentConfig, request: Request, user: dict |
         uid = config.owner_hint or os.environ.get("FD_OWNER_ID", "")
 
     from captain_claw.flight_deck.archetypes import merged_archetypes
+    from captain_claw.flight_deck.archetype_compose import resolve_pair
     from captain_claw.flight_deck.auth import get_db
-    try:
-        arch = next(
-            (a for a in await merged_archetypes(get_db(), uid or None) if a.get("id") == aid),
-            None,
-        )
-    except Exception as exc:
-        log.warning("Archetype resolution failed; spawning config as-is",
-                    archetype=aid, error=str(exc))
-        return
+    # Function×domain grid (flag-gated): a `function.domain` selector composes a
+    # leaf from the two axis registries. None when the flag is off, the id isn't a
+    # pair, or an axis is unknown — in which case we fall through to the normal
+    # single-id lookup below, so base/user archetypes behave exactly as before.
+    arch = resolve_pair(aid)
+    if arch is None:
+        try:
+            arch = next(
+                (a for a in await merged_archetypes(get_db(), uid or None) if a.get("id") == aid),
+                None,
+            )
+        except Exception as exc:
+            log.warning("Archetype resolution failed; spawning config as-is",
+                        archetype=aid, error=str(exc))
+            return
     if not arch:
         log.warning("Unknown archetype; spawning config as-is", archetype=aid)
         return
@@ -1331,6 +1353,12 @@ async def _resolve_archetype(config: AgentConfig, request: Request, user: dict |
         config.description = str(arch.get("role") or arch.get("description") or f"archetype:{aid}")
     if not config.runtime and arch.get("runtime") in ("classic", "mrav"):
         config.runtime = str(arch["runtime"])
+    # Composed function×domain leaves carry deep-memory grid config; base/user
+    # archetypes don't, so these stay empty (today's behaviour) for them.
+    if arch.get("memory_tags"):
+        config.grid_memory_tags = [str(t) for t in arch["memory_tags"]]
+    if arch.get("recall_mode"):
+        config.grid_recall_mode = str(arch["recall_mode"])
 
     # Model: the requested tier (`@tier` wins, else the archetype's own default
     # tier) resolved against the OWNER's Library tier config — the same source
@@ -1855,6 +1883,10 @@ async def spawn_agent(config: AgentConfig, request: Request, user: dict | None =
         "flight-deck.image": config.image,
         "flight-deck.web-port": str(config.web_port) if config.web_enabled else "",
         "flight-deck.web-auth": config.web_auth_token or "",
+        # Deep-memory grid config, mirrored from the process registry so a
+        # containerised agent resolves the same tags/recall via its Docker labels.
+        "flight-deck.grid-tags": json.dumps(list(config.grid_memory_tags or [])),
+        "flight-deck.grid-recall": config.grid_recall_mode or "",
     }
 
     # Security options
@@ -3092,6 +3124,61 @@ def _resolve_agent_owner_by_auth(token: str) -> str:
         if entry.get("web_auth") == token and entry.get("owner"):
             return entry["owner"]
     return ""
+
+
+def _parse_grid_labels(labels: dict) -> tuple[list[str], str]:
+    """Grid config from Docker labels: `flight-deck.grid-tags` (JSON list) and
+    `flight-deck.grid-recall`. Malformed → empty (never breaks resolution)."""
+    try:
+        tags = json.loads(labels.get("flight-deck.grid-tags") or "[]")
+    except Exception:
+        tags = []
+    if not isinstance(tags, list):
+        tags = []
+    return [str(t) for t in tags], str(labels.get("flight-deck.grid-recall") or "")
+
+
+def _resolve_agent_grid_by_auth(token: str) -> tuple[list[str], str]:
+    """Resolve an agent's deep-memory grid config (memory tags, recall mode) by
+    its unique web_auth token — the same authority as `_resolve_agent_owner_by_auth`.
+    Returns ([], "") for a non-grid agent, so the proxy pools by owner unchanged."""
+    if not token:
+        return [], ""
+    try:
+        client = get_docker()
+        for c in client.containers.list(filters={"label": CONTAINER_LABEL}):
+            labels = c.labels or {}
+            if labels.get("flight-deck.web-auth", "") == token:
+                return _parse_grid_labels(labels)
+    except Exception:
+        pass
+    for slug, entry in _load_process_registry().items():
+        if entry.get("web_auth") == token:
+            return list(entry.get("grid_tags") or []), str(entry.get("grid_recall") or "")
+    return [], ""
+
+
+def _resolve_agent_grid(port: int) -> tuple[list[str], str]:
+    """Port-keyed fallback for `_resolve_agent_grid_by_auth`, mirroring
+    `_resolve_agent_owner`. Prefers a live process over stale same-port entries."""
+    try:
+        client = get_docker()
+        for c in client.containers.list(filters={"label": CONTAINER_LABEL}):
+            labels = c.labels or {}
+            wp = labels.get("flight-deck.web-port", "")
+            if wp and int(wp) == port:
+                return _parse_grid_labels(labels)
+    except Exception:
+        pass
+    registry = _load_process_registry()
+    matches = [(slug, e) for slug, e in registry.items() if e.get("web_port") == port]
+    for slug, entry in matches:
+        if _process_is_alive(slug):
+            return list(entry.get("grid_tags") or []), str(entry.get("grid_recall") or "")
+    if matches:
+        e = matches[0][1]
+        return list(e.get("grid_tags") or []), str(e.get("grid_recall") or "")
+    return [], ""
 
 
 # ── Flow engine helpers ────────────────────────────────────────────────
@@ -5800,6 +5887,11 @@ async def _spawn_process_locked(config: AgentConfig, request: Request, user: dic
         "model": config.model,
         "tier": config.tier,
         "owner": owner_id,
+        # Deep-memory grid config (empty for non-grid agents) — the FD deep-memory
+        # proxy reads these to stamp write-tags and narrow reads without the agent
+        # asserting anything (mirrors how `owner` is server-resolved).
+        "grid_tags": list(config.grid_memory_tags or []),
+        "grid_recall": config.grid_recall_mode or "",
     }
     _save_process_registry(registry)
 

--- a/captain_claw/instructions/domains.json
+++ b/captain_claw/instructions/domains.json
@@ -1,0 +1,23 @@
+{
+  "description": "Domain axis for the function×domain archetype grid (PROTOTYPE, flag-gated by FD_ARCHETYPE_GRID). Each entry is the 'what it's about' half of a composed leaf: an instruction `overlay` appended after the function's, optional `tools_add`, an optional `tier_floor` that can only RAISE the composed tier, and an optional `recall_override` (pool | domain | self) that overrides the function's recall breadth. Supplies the `domain:<id>` deep-memory tag. Composed with a function from functions.json. Edit a domain here once and every function's variant of it updates.",
+  "domains": [
+    {
+      "id": "legal",
+      "label": "Legal",
+      "tier_floor": "reason",
+      "tools_add": [],
+      "recall_override": "domain",
+      "keywords": ["contract", "clause", "liability", "compliance", "statute"],
+      "overlay": "## Domain: Legal\nYou operate in a legal context. Ground every substantive statement in a specific statute, regulation, contract clause, or the user's own documents — never assert law from memory alone. Distinguish settled law from interpretation. Flag clearly anything that requires a licensed attorney's judgment, and never present your output as legal advice. Prefer precision and explicit caveats over confident generality."
+    },
+    {
+      "id": "finance",
+      "label": "Finance",
+      "tier_floor": "balanced",
+      "tools_add": [],
+      "recall_override": null,
+      "keywords": ["revenue", "margin", "valuation", "cashflow", "forecast"],
+      "overlay": "## Domain: Finance\nYou operate in a financial context. State the currency, period, and basis (actual vs forecast, gross vs net) for every figure. Keep assumptions explicit and separate from results. Never give personalized investment advice; describe trade-offs and let the user decide. Sanity-check totals and reconcile against any stated source of truth."
+    }
+  ]
+}

--- a/captain_claw/instructions/functions.json
+++ b/captain_claw/instructions/functions.json
@@ -1,0 +1,53 @@
+{
+  "description": "Function axis for the function×domain archetype grid (PROTOTYPE, flag-gated by FD_ARCHETYPE_GRID). Each entry is the 'how it works' half of a composed leaf: role, SOP, base tools, cognitive_mode, and recall_mode. Composed with a domain from domains.json by captain_claw.flight_deck.archetype_compose.compose_archetype. A grid agent is selected as `archetype:<function_id>.<domain_id>[@tier]` (e.g. `reviewer.legal`). Edit a function here once and every domain's variant of it updates.",
+  "functions": [
+    {
+      "id": "researcher",
+      "role": "Researcher",
+      "description": "Sources, gathers, and structures evidence on a question.",
+      "cognitive_mode": "ionian",
+      "tier": "balanced",
+      "tools": ["web_search", "web_fetch", "read", "insights", "todo"],
+      "recall_mode": "pool",
+      "keywords": ["research", "sources", "evidence", "investigate"],
+      "reliability_seed": 0.72,
+      "fleet_instructions": "You are a Researcher. Given a question, you find, read, and organize the best available evidence, then hand back a structured, sourced brief.\n\n## Standard Operating Procedure\n1. Restate the question and the decision it feeds.\n2. Gather from multiple independent sources; prefer primary over secondary.\n3. Keep every claim that matters next to the source that supports it.\n4. Separate what the evidence says from what you infer.\n5. Return a structured brief: findings, confidence, and open gaps.\n\nUse `insights` to remember durable facts across sessions and `todo` to track follow-ups."
+    },
+    {
+      "id": "writer",
+      "role": "Writer",
+      "description": "Turns raw material and briefs into clear finished prose.",
+      "cognitive_mode": "aeolian",
+      "tier": "balanced",
+      "tools": ["read", "write", "insights", "todo"],
+      "recall_mode": "pool",
+      "keywords": ["write", "draft", "edit", "prose"],
+      "reliability_seed": 0.7,
+      "fleet_instructions": "You are a Writer. You turn briefs, notes, and source material into clear, well-structured finished text for a stated audience.\n\n## Standard Operating Procedure\n1. Confirm audience, purpose, length, and voice.\n2. Outline before drafting; lead with the point.\n3. Draft, then cut every sentence that doesn't earn its place.\n4. Keep claims traceable to the brief; flag anything you couldn't ground.\n5. Return the finished text plus a one-line note on the choices you made.\n\nUse `insights` for the house style and recurring preferences."
+    },
+    {
+      "id": "reviewer",
+      "role": "Reviewer",
+      "description": "Critically checks work against its brief and standards.",
+      "cognitive_mode": "locrian",
+      "tier": "balanced",
+      "tools": ["read", "insights", "todo"],
+      "recall_mode": "pool",
+      "keywords": ["review", "critique", "check", "quality"],
+      "reliability_seed": 0.74,
+      "fleet_instructions": "You are a Reviewer. You examine a piece of work against its brief, its domain standards, and plain correctness, and return specific, actionable findings.\n\n## Standard Operating Procedure\n1. Restate what the work is trying to achieve and the bar it must clear.\n2. Read closely; check claims, structure, and fit to the brief.\n3. Report findings most-important first, each with a concrete fix.\n4. Separate must-fix from nice-to-have.\n5. Never rubber-stamp; when it's good, say precisely why.\n\nUse `insights` to remember recurring issues and standards."
+    },
+    {
+      "id": "analyst",
+      "role": "Analyst",
+      "description": "Works numbers and data into decision-ready findings.",
+      "cognitive_mode": "dorian",
+      "tier": "balanced",
+      "tools": ["read", "write", "shell", "insights", "todo"],
+      "recall_mode": "pool",
+      "keywords": ["analysis", "data", "numbers", "metrics"],
+      "reliability_seed": 0.71,
+      "fleet_instructions": "You are an Analyst. You take data and turn it into clear, defensible, decision-ready findings.\n\n## Standard Operating Procedure\n1. Confirm the question and what decision the numbers inform.\n2. Check the data's shape and quality before trusting it.\n3. Compute, then sanity-check every result against a rough expectation.\n4. State findings with their uncertainty; show the key numbers.\n5. Lead with the 'so what', not the method.\n\nUse `insights` to remember data sources and definitions."
+    }
+  ]
+}

--- a/tests/test_flight_deck/test_archetype_compose.py
+++ b/tests/test_flight_deck/test_archetype_compose.py
@@ -131,11 +131,22 @@ def test_recall_filter_empty_mode_is_pool():
     assert gc.recall_filter(None, ["domain:legal"]) == ""
 
 
-def test_recall_filter_domain_narrows_to_domain_tag():
-    assert gc.recall_filter("domain", ["agent:reviewer", "domain:legal"]) == "tags:=`domain:legal`"
+def test_recall_filter_domain_includes_own_domain_general_and_documents():
+    # domain recall = my domain OR the shared sentinel OR any non-agent (document) row
+    assert gc.recall_filter("domain", ["agent:reviewer", "domain:legal"]) == (
+        "(tags:=`domain:legal` || tags:=`domain:general` || source:!=`agent`)"
+    )
+
+
+def test_recall_filter_domain_excludes_other_domains():
+    # A legal specialist's filter matches domain:legal but not domain:finance —
+    # finance-tagged agent rows fail all three clauses.
+    f = gc.recall_filter("domain", ["agent:reviewer", "domain:legal"])
+    assert "domain:legal" in f and "domain:finance" not in f
 
 
 def test_recall_filter_self_narrows_to_agent_tag():
+    # self stays strict: only the agent's own rows, no documents, no sharing.
     assert gc.recall_filter("self", ["agent:reviewer", "domain:legal"]) == "tags:=`agent:reviewer`"
 
 

--- a/tests/test_flight_deck/test_archetype_compose.py
+++ b/tests/test_flight_deck/test_archetype_compose.py
@@ -1,0 +1,236 @@
+"""Tests for the function×domain archetype grid (PROTOTYPE, FD_ARCHETYPE_GRID).
+
+Covers the pure composition core (`parse_pair`, `_max_tier`, `compose_archetype`),
+the flag-gated `resolve_pair` (including against the real shipped registries), and
+the `server._resolve_archetype` seam branch that folds a composed pair into a spawn
+config when the flag is on and defers to the base lookup when it is off.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import captain_claw.flight_deck.archetype_compose as gc
+import captain_claw.flight_deck.server as server
+
+
+def _req(uid: str = ""):
+    return types.SimpleNamespace(state=types.SimpleNamespace(user_id=uid))
+
+
+# ── parse_pair ───────────────────────────────────────────────────────
+
+def test_parse_pair_splits_function_and_domain():
+    assert gc.parse_pair("reviewer.legal") == ("reviewer", "legal")
+
+
+def test_parse_pair_plain_id_has_no_domain():
+    assert gc.parse_pair("code-reviewer") == ("code-reviewer", None)
+
+
+def test_parse_pair_first_dot_only():
+    # A function id may not contain a dot; a domain id may.
+    assert gc.parse_pair("writer.us.finance") == ("writer", "us.finance")
+
+
+def test_parse_pair_empty_half_is_not_a_pair():
+    assert gc.parse_pair("reviewer.") == ("reviewer.", None)
+    assert gc.parse_pair(".legal") == (".legal", None)
+
+
+# ── _max_tier ────────────────────────────────────────────────────────
+
+def test_max_tier_floor_raises():
+    assert gc._max_tier("balanced", "reason") == "reason"
+
+
+def test_max_tier_floor_lower_is_noop():
+    assert gc._max_tier("reason", "balanced") == "reason"
+
+
+def test_max_tier_no_floor_keeps_function_tier():
+    assert gc._max_tier("fast", None) == "fast"
+
+
+def test_max_tier_unknown_tier_does_not_raise():
+    # A specialist tier outside the ladder → no floor applied, function tier kept.
+    assert gc._max_tier("balanced", "coding") == "balanced"
+    assert gc._max_tier("vision", "reason") == "vision"
+
+
+# ── compose_archetype ────────────────────────────────────────────────
+
+def _fn():
+    return {
+        "id": "reviewer", "role": "Reviewer", "cognitive_mode": "locrian",
+        "tier": "balanced", "tools": ["read", "insights"], "recall_mode": "pool",
+        "keywords": ["review"], "fleet_instructions": "You are a Reviewer.\nSOP here.",
+    }
+
+
+def _dm():
+    return {
+        "id": "legal", "label": "Legal", "tier_floor": "reason",
+        "tools_add": ["citation_lookup"], "recall_override": "domain",
+        "keywords": ["contract"], "overlay": "## Domain: Legal\nGround claims in statute.",
+    }
+
+
+def test_compose_id_role_and_family():
+    c = gc.compose_archetype(_fn(), _dm())
+    assert c["id"] == "reviewer.legal"
+    assert c["role"] == "Legal Reviewer"
+    assert c["family"] == "Legal"
+
+
+def test_compose_instructions_are_function_then_overlay():
+    c = gc.compose_archetype(_fn(), _dm())
+    assert c["fleet_instructions"].startswith("You are a Reviewer.")
+    assert c["fleet_instructions"].endswith("Ground claims in statute.")
+    assert "## Domain: Legal" in c["fleet_instructions"]
+
+
+def test_compose_tools_are_union():
+    c = gc.compose_archetype(_fn(), _dm())
+    assert c["tools"] == ["citation_lookup", "insights", "read"]  # sorted union
+
+
+def test_compose_tier_raised_to_domain_floor():
+    c = gc.compose_archetype(_fn(), _dm())
+    assert c["tier"] == "reason"
+
+
+def test_compose_cognitive_mode_is_functions():
+    assert gc.compose_archetype(_fn(), _dm())["cognitive_mode"] == "locrian"
+
+
+def test_compose_recall_override_wins():
+    assert gc.compose_archetype(_fn(), _dm())["recall_mode"] == "domain"
+
+
+def test_compose_recall_defaults_to_function_when_no_override():
+    dm = _dm()
+    dm["recall_override"] = None
+    assert gc.compose_archetype(_fn(), dm)["recall_mode"] == "pool"
+
+
+def test_compose_memory_tags_carry_both_axes():
+    assert gc.compose_archetype(_fn(), _dm())["memory_tags"] == ["agent:reviewer", "domain:legal"]
+
+
+# ── recall_filter ────────────────────────────────────────────────────
+
+def test_recall_filter_pool_is_empty():
+    assert gc.recall_filter("pool", ["agent:reviewer", "domain:legal"]) == ""
+
+
+def test_recall_filter_empty_mode_is_pool():
+    assert gc.recall_filter("", ["domain:legal"]) == ""
+    assert gc.recall_filter(None, ["domain:legal"]) == ""
+
+
+def test_recall_filter_domain_narrows_to_domain_tag():
+    assert gc.recall_filter("domain", ["agent:reviewer", "domain:legal"]) == "tags:=`domain:legal`"
+
+
+def test_recall_filter_self_narrows_to_agent_tag():
+    assert gc.recall_filter("self", ["agent:reviewer", "domain:legal"]) == "tags:=`agent:reviewer`"
+
+
+def test_recall_filter_missing_tag_degrades_to_pool():
+    assert gc.recall_filter("domain", ["agent:reviewer"]) == ""   # no domain: tag
+    assert gc.recall_filter("self", ["domain:legal"]) == ""       # no agent: tag
+    assert gc.recall_filter("domain", []) == ""
+
+
+def test_recall_filter_unknown_mode_is_pool():
+    assert gc.recall_filter("everything", ["domain:legal"]) == ""
+
+
+# ── resolve_pair (flag gating + real registries) ─────────────────────
+
+def test_resolve_pair_off_by_default(monkeypatch):
+    monkeypatch.delenv("FD_ARCHETYPE_GRID", raising=False)
+    assert gc.resolve_pair("reviewer.legal") is None
+
+
+def test_resolve_pair_flag_off_returns_none_even_for_valid_pair(monkeypatch):
+    monkeypatch.setenv("FD_ARCHETYPE_GRID", "0")
+    assert gc.resolve_pair("reviewer.legal") is None
+
+
+def test_resolve_pair_plain_id_is_none_when_flag_on(monkeypatch):
+    monkeypatch.setenv("FD_ARCHETYPE_GRID", "1")
+    assert gc.resolve_pair("code-reviewer") is None
+
+
+def test_resolve_pair_unknown_axis_is_none(monkeypatch):
+    monkeypatch.setenv("FD_ARCHETYPE_GRID", "1")
+    assert gc.resolve_pair("reviewer.nope") is None
+    assert gc.resolve_pair("nope.legal") is None
+
+
+def test_resolve_pair_shipped_registry_composes(monkeypatch):
+    """Against the real functions.json / domains.json this repo ships."""
+    monkeypatch.setenv("FD_ARCHETYPE_GRID", "true")
+    c = gc.resolve_pair("reviewer.legal")
+    assert c is not None
+    assert c["id"] == "reviewer.legal"
+    assert c["role"] == "Legal Reviewer"
+    assert c["tier"] == "reason"                       # legal floor raises balanced
+    assert c["recall_mode"] == "domain"                # legal recall_override
+    assert c["memory_tags"] == ["agent:reviewer", "domain:legal"]
+    assert "## Domain: Legal" in c["fleet_instructions"]
+
+
+def test_resolve_pair_finance_keeps_function_recall(monkeypatch):
+    monkeypatch.setenv("FD_ARCHETYPE_GRID", "1")
+    c = gc.resolve_pair("researcher.finance")
+    assert c is not None
+    assert c["recall_mode"] == "pool"                  # finance has no override
+    assert c["tier"] == "balanced"                     # floor == function tier, no raise
+
+
+# ── server._resolve_archetype seam branch ────────────────────────────
+
+@pytest.fixture
+def patch_owner_tiers(monkeypatch: pytest.MonkeyPatch):
+    """Stub the owner-tier + db seams so the resolver needs no DB. Empty tiers →
+    the composed archetype's tier is left for `_resolve_tier`, model untouched."""
+    import captain_claw.flight_deck.auth as auth_mod
+    import captain_claw.flight_deck.basna_routes as basna_mod
+
+    async def fake_owner_tiers(db, uid):
+        return {}, []
+
+    monkeypatch.setattr(auth_mod, "get_db", lambda: object())
+    monkeypatch.setattr(basna_mod, "_load_owner_tiers", fake_owner_tiers)
+
+
+async def test_seam_folds_composed_pair_when_flag_on(monkeypatch, patch_owner_tiers):
+    monkeypatch.setenv("FD_ARCHETYPE_GRID", "1")
+    cfg = server.AgentConfig(name="x", archetype="reviewer.legal")
+    await server._resolve_archetype(cfg, _req(), None)
+    assert cfg.cognitive_mode == "locrian"             # from the reviewer function
+    assert cfg.description == "Legal Reviewer"          # composed role
+    assert "read" in cfg.tools and "insights" in cfg.tools
+
+
+async def test_seam_defers_to_base_lookup_when_flag_off(monkeypatch, patch_owner_tiers):
+    """Flag off → the dotted id is not composed; the base lookup finds nothing and
+    the resolver is a non-fatal no-op that leaves the config untouched."""
+    monkeypatch.delenv("FD_ARCHETYPE_GRID", raising=False)
+
+    import captain_claw.flight_deck.archetypes as arch_mod
+
+    async def empty_merged(db, uid):
+        return []
+
+    monkeypatch.setattr(arch_mod, "merged_archetypes", empty_merged)
+    cfg = server.AgentConfig(name="x", archetype="reviewer.legal")
+    before = cfg.model_copy(deep=True)
+    await server._resolve_archetype(cfg, _req(), None)
+    assert cfg.cognitive_mode == before.cognitive_mode  # unchanged
+    assert cfg.description == before.description

--- a/tests/test_flight_deck/test_deep_memory_grid.py
+++ b/tests/test_flight_deck/test_deep_memory_grid.py
@@ -70,11 +70,28 @@ async def test_index_stamps_grid_tags(stub_proxy):
     assert stub_proxy.index.indexed["owner_id"] == "alice"
 
 
-async def test_index_non_grid_agent_writes_no_tags(stub_proxy):
+async def test_index_non_grid_agent_writes_no_tags_when_grid_off(stub_proxy, monkeypatch):
+    monkeypatch.delenv("FD_ARCHETYPE_GRID", raising=False)
     stub_proxy.grid = ([], "")
     body = dr.AgentIndexBody(text="plain note")
     await dr.agent_index(body, _req())
     assert stub_proxy.index.indexed["tags"] is None   # index_document drops falsy tags
+
+
+async def test_index_non_grid_agent_marked_general_when_grid_on(stub_proxy, monkeypatch):
+    # With the grid on, a domainless agent's output is stamped domain:general so a
+    # specialist's narrowed recall still sees it.
+    monkeypatch.setenv("FD_ARCHETYPE_GRID", "1")
+    stub_proxy.grid = ([], "")
+    await dr.agent_index(dr.AgentIndexBody(text="cross-cutting note"), _req())
+    assert stub_proxy.index.indexed["tags"] == ["domain:general"]
+
+
+async def test_index_grid_agent_keeps_its_domain_not_general(stub_proxy, monkeypatch):
+    monkeypatch.setenv("FD_ARCHETYPE_GRID", "1")
+    stub_proxy.grid = (["agent:reviewer", "domain:legal"], "domain")
+    await dr.agent_index(dr.AgentIndexBody(text="a legal finding"), _req())
+    assert stub_proxy.index.indexed["tags"] == ["agent:reviewer", "domain:legal"]
 
 
 # ── /agent/search — recall narrowing ─────────────────────────────────
@@ -85,16 +102,19 @@ async def test_search_pool_leaves_filter_untouched(stub_proxy):
     assert stub_proxy.search_filter == ""
 
 
-async def test_search_domain_ands_domain_tag(stub_proxy):
+_DOMAIN_LEGAL = "(tags:=`domain:legal` || tags:=`domain:general` || source:!=`agent`)"
+
+
+async def test_search_domain_includes_domain_general_and_documents(stub_proxy):
     stub_proxy.grid = (["agent:reviewer", "domain:legal"], "domain")
     await dr.agent_search(dr.AgentSearchBody(query="q"), _req())
-    assert stub_proxy.search_filter == "tags:=`domain:legal`"
+    assert stub_proxy.search_filter == _DOMAIN_LEGAL
 
 
 async def test_search_domain_ands_onto_caller_filter(stub_proxy):
     stub_proxy.grid = (["agent:reviewer", "domain:legal"], "domain")
     await dr.agent_search(dr.AgentSearchBody(query="q", filter_by="source:=agent"), _req())
-    assert stub_proxy.search_filter == "(source:=agent) && tags:=`domain:legal`"
+    assert stub_proxy.search_filter == f"(source:=agent) && {_DOMAIN_LEGAL}"
 
 
 async def test_search_self_ands_agent_tag(stub_proxy):

--- a/tests/test_flight_deck/test_deep_memory_grid.py
+++ b/tests/test_flight_deck/test_deep_memory_grid.py
@@ -1,0 +1,150 @@
+"""Deep-memory grid wiring: the FD proxy stamps an agent's axis tags on write and
+narrows its reads by recall_mode — without the agent asserting anything.
+
+Exercises the `/agent/index` and `/agent/search` route functions directly with a
+stub Request and stubbed identity/connection/index seams, plus the server-side
+grid resolvers that read the process registry.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import captain_claw.flight_deck.deep_memory_routes as dr
+import captain_claw.flight_deck.server as server
+
+
+def _req(port: int = 41000, token: str = ""):
+    headers = {"X-Agent-Auth": token} if token else {}
+    return types.SimpleNamespace(
+        headers=headers,
+        client=types.SimpleNamespace(host="127.0.0.1", port=port),
+    )
+
+
+class _FakeIndex:
+    """Captures index_document kwargs and delete_by_reference calls."""
+
+    def __init__(self):
+        self.indexed: dict = {}
+        self.deleted: list = []
+
+    def delete_by_reference(self, reference, owner_id=""):
+        self.deleted.append((reference, owner_id))
+        return 0
+
+    def index_document(self, **kwargs):
+        self.indexed = kwargs
+        return 3
+
+
+@pytest.fixture
+def stub_proxy(monkeypatch):
+    """Stub owner, connection, and index/search so the routes need no Typesense.
+    Returns a namespace whose `.grid` / `.search_filter` the test can set/read."""
+    ns = types.SimpleNamespace(index=_FakeIndex(), grid=([], ""), search_filter=None)
+
+    monkeypatch.setattr(dr, "_agent_owner", lambda request: "alice")
+    monkeypatch.setattr(dr, "_agent_grid", lambda request: ns.grid)
+    monkeypatch.setattr(dr, "_require_connection", lambda: None)
+    monkeypatch.setattr(dr.svc, "get_index", lambda: ns.index)
+
+    def fake_search(owner_id, query, *, max_results=10, filter_by=""):
+        ns.search_filter = filter_by
+        return [{"owner": owner_id, "q": query}]
+
+    monkeypatch.setattr(dr.svc, "search", fake_search)
+    return ns
+
+
+# ── /agent/index — tag stamping ──────────────────────────────────────
+
+async def test_index_stamps_grid_tags(stub_proxy):
+    stub_proxy.grid = (["agent:reviewer", "domain:legal"], "domain")
+    body = dr.AgentIndexBody(text="a legal finding", reference="ref1")
+    out = await dr.agent_index(body, _req())
+    assert out["ok"] is True
+    assert stub_proxy.index.indexed["tags"] == ["agent:reviewer", "domain:legal"]
+    assert stub_proxy.index.indexed["owner_id"] == "alice"
+
+
+async def test_index_non_grid_agent_writes_no_tags(stub_proxy):
+    stub_proxy.grid = ([], "")
+    body = dr.AgentIndexBody(text="plain note")
+    await dr.agent_index(body, _req())
+    assert stub_proxy.index.indexed["tags"] is None   # index_document drops falsy tags
+
+
+# ── /agent/search — recall narrowing ─────────────────────────────────
+
+async def test_search_pool_leaves_filter_untouched(stub_proxy):
+    stub_proxy.grid = (["agent:researcher", "domain:finance"], "pool")
+    await dr.agent_search(dr.AgentSearchBody(query="q"), _req())
+    assert stub_proxy.search_filter == ""
+
+
+async def test_search_domain_ands_domain_tag(stub_proxy):
+    stub_proxy.grid = (["agent:reviewer", "domain:legal"], "domain")
+    await dr.agent_search(dr.AgentSearchBody(query="q"), _req())
+    assert stub_proxy.search_filter == "tags:=`domain:legal`"
+
+
+async def test_search_domain_ands_onto_caller_filter(stub_proxy):
+    stub_proxy.grid = (["agent:reviewer", "domain:legal"], "domain")
+    await dr.agent_search(dr.AgentSearchBody(query="q", filter_by="source:=agent"), _req())
+    assert stub_proxy.search_filter == "(source:=agent) && tags:=`domain:legal`"
+
+
+async def test_search_self_ands_agent_tag(stub_proxy):
+    stub_proxy.grid = (["agent:analyst", "domain:finance"], "self")
+    await dr.agent_search(dr.AgentSearchBody(query="q"), _req())
+    assert stub_proxy.search_filter == "tags:=`agent:analyst`"
+
+
+# ── server-side grid resolvers (registry path; Docker skipped) ───────
+
+@pytest.fixture
+def stub_registry(monkeypatch):
+    """Force the Docker branch to no-op and drive the process-registry branch."""
+    monkeypatch.setattr(server, "get_docker", lambda: (_ for _ in ()).throw(RuntimeError("no docker")))
+    reg = {
+        "cc-rev": {
+            "web_auth": "tok-rev", "web_port": 41000,
+            "grid_tags": ["agent:reviewer", "domain:legal"], "grid_recall": "domain",
+        },
+        "cc-plain": {"web_auth": "tok-plain", "web_port": 41001},  # non-grid
+    }
+    monkeypatch.setattr(server, "_load_process_registry", lambda: reg)
+    monkeypatch.setattr(server, "_process_is_alive", lambda slug: True)
+    return reg
+
+
+def test_resolve_grid_by_auth_returns_tags_and_mode(stub_registry):
+    tags, recall = server._resolve_agent_grid_by_auth("tok-rev")
+    assert tags == ["agent:reviewer", "domain:legal"]
+    assert recall == "domain"
+
+
+def test_resolve_grid_by_auth_non_grid_is_empty(stub_registry):
+    assert server._resolve_agent_grid_by_auth("tok-plain") == ([], "")
+
+
+def test_resolve_grid_by_auth_unknown_token_is_empty(stub_registry):
+    assert server._resolve_agent_grid_by_auth("nope") == ([], "")
+
+
+def test_resolve_grid_by_port(stub_registry):
+    assert server._resolve_agent_grid(41000) == (["agent:reviewer", "domain:legal"], "domain")
+
+
+def test_parse_grid_labels_reads_docker_labels():
+    labels = {"flight-deck.grid-tags": '["agent:writer","domain:finance"]',
+              "flight-deck.grid-recall": "pool"}
+    assert server._parse_grid_labels(labels) == (["agent:writer", "domain:finance"], "pool")
+
+
+def test_parse_grid_labels_malformed_is_empty():
+    assert server._parse_grid_labels({"flight-deck.grid-tags": "{not json"}) == ([], "")
+    assert server._parse_grid_labels({}) == ([], "")


### PR DESCRIPTION
## Summary

A **function×domain archetype grid** for the team-of-N use case: instead of storing F×M flat leaf archetypes, keep two small axis registries and **compose a leaf on the fly at spawn**. Editing one function or one domain updates every variant — a role that is *living on both axes*. Behind the `FD_ARCHETYPE_GRID` flag (default off); when off, or when an id is not a resolvable pair, every existing spawn path is byte-for-byte unchanged.

Paired with a **per-user deep-memory pool**: because an FD agent proxies deep memory through Flight Deck (which server-derives `owner_id` = the user), a user's agents already pool and are isolated across users. This adds axis *slicing* on top — writes are tagged `agent:<fn>` / `domain:<dm>`, and reads are narrowed by the agent's `recall_mode`.

## What's in it

**Composition** (`archetype_compose.py`, `instructions/functions.json` × `instructions/domains.json`)
- `reviewer.legal` = Reviewer SOP + Legal overlay, tools unioned, tier raised to the domain's floor, recall_mode = domain override or function default.
- Two flag-gated seam branches resolve a `function.domain` pair *before* the normal single-id lookup: `_resolve_archetype` (container selector) and `_flow_load_archetype` (flow → dubina). Base ids never contain a dot, so a dotted id is an unambiguous grid selector. Fail-open.

**Deep-memory pooling** (`deep_memory_routes.py`, `server.py`, `dubina_agents.py`)
- Composed grid config (`memory_tags`, `recall_mode`) rides `AgentConfig` through the single `spawn_process` path into the process-registry entry + Docker labels; server-side resolvers mirror the owner resolvers so the agent asserts nothing.
- `/agent/index` stamps the axis tags; `/agent/search` ANDs a recall filter onto the caller's `filter_by`. `owner_id` is still ANDed inside the index, so tags only ever **narrow within a tenant, never widen** past the owner.
- **Recall modes:** `pool` (whole user pool) · `domain` (own domain + `domain:general` + all non-agent documents, so specialists still see shared docs, while other domains' agent memories stay excluded) · `self` (strict, own tag only).

## Tests
- 45 grid tests (compose, recall_filter, tag-stamping, recall narrowing, general-sentinel sharing, registry resolvers).
- 66 regression across spawn / flow / dubina / deep-memory — all pass.

## Follow-ups (not in this PR)
- Route function/domain edits through a draft → eval-gate → publish flow so "living on both axes" is safe at team scale.
- Per-user overlays of the function/domain registries (mirroring `user_archetypes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)