### PR TITLE
fix(llm): self-heal forced tool_choice a thinking-mode model rejects (streaming)

### DIFF
--- a/captain_claw/llm/__init__.py
+++ b/captain_claw/llm/__init__.py
@@ -321,6 +321,19 @@ def _is_reasoning_content_required_error(msg: str) -> bool:
     )
 
 
+def _is_tool_choice_unsupported_error(msg: str) -> bool:
+    """True for the 400 a thinking/reasoning model returns when it won't accept
+    a forced ``tool_choice`` — e.g. a DeepSeek/Kimi thinking mode served over an
+    OpenAI-compatible endpoint: "Thinking mode does not support this tool_choice".
+
+    Recovered the same way everywhere: drop the forced constraint and let the
+    model answer normally, then flag the provider so later calls skip forcing it.
+    Requires the literal ``tool_choice`` token so it never swallows unrelated
+    400s that merely mention support.
+    """
+    return "tool_choice" in msg and ("support" in msg or "not allowed" in msg)
+
+
 def _backfill_reasoning_content(messages: Any) -> bool:
     """Ensure every assistant message carries a non-empty reasoning_content,
     injecting :data:`_REASONING_BACKFILL_PLACEHOLDER` where one is missing.
@@ -378,8 +391,7 @@ async def _acompletion_tolerant(kwargs: dict[str, Any], provider: Any = None) ->
         # Model rejects tool_choice (thinking-mode models).
         if (
             kwargs.get("tool_choice") is not None
-            and "tool_choice" in msg
-            and "support" in msg
+            and _is_tool_choice_unsupported_error(msg)
         ):
             retry_kwargs.pop("tool_choice", None)
             stripped.append("tool_choice")
@@ -3060,7 +3072,15 @@ class LiteLLMProvider(LLMProvider):
                 if m:
                     model = m
         except Exception as e:
-            # Preserve whatever we collected so far rather than losing
+            # A forced tool_choice a thinking-mode model rejects surfaces here
+            # (during stream consumption) as a pre-flight 400 — nothing was
+            # streamed, so there's no partial content to preserve. Re-raise it
+            # so the caller (complete_with_callback / complete) can drop the
+            # constraint and retry, instead of silently returning an empty
+            # response.
+            if _is_tool_choice_unsupported_error(str(e).lower()):
+                raise
+            # Otherwise preserve whatever we collected so far rather than losing
             # the entire response.  Log so we can diagnose.
             log.warning(
                 "Stream collection interrupted, returning partial content",
@@ -3349,46 +3369,72 @@ class LiteLLMProvider(LLMProvider):
         _reasoning_parts: list[str] = []
         self.last_reasoning_content = ""
 
+        kwargs = self._request_kwargs(
+            messages=messages,
+            tools=tools,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=True,
+        )
         try:
-            stream = await _acompletion_tolerant(
-                self._request_kwargs(
-                    messages=messages,
-                    tools=tools,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    stream=True,
-                ),
-                self,
-            )
-            async for chunk in stream:
-                delta_obj = _obj_get(_obj_get(chunk, "choices", [{}])[0], "delta", {})
-                # Accumulate reasoning_content (Grok, DeepSeek, etc.)
-                # without yielding it as user-visible text. Replayed
-                # on the next turn so DeepSeek doesn't 400.
-                _rc = (
-                    _obj_get(delta_obj, "reasoning_content", None)
-                    or _obj_get(delta_obj, "thinking", None)
-                    or _obj_get(delta_obj, "reasoning", None)
-                )
-                if _rc:
-                    _reasoning_parts.append(str(_rc))
-                    continue
-                delta = _obj_get(delta_obj, "content", "")
-                if not delta:
-                    continue
-                if isinstance(delta, str):
-                    yield delta
-                    continue
-                if isinstance(delta, list):
-                    text_parts: list[str] = []
-                    for part in delta:
-                        text = _obj_get(part, "text", "")
-                        if text:
-                            text_parts.append(str(text))
-                    if text_parts:
-                        yield "".join(text_parts)
-                    continue
-                yield str(delta)
+            yielded_any = False
+            # At most two attempts: the second drops a forced tool_choice a
+            # thinking-mode model rejects. That 400 surfaces during iteration
+            # (not on the acompletion() call), so _acompletion_tolerant never
+            # sees it; we retry here, but only before any visible chunk has been
+            # yielded (the 400 is a pre-flight rejection, so nothing streamed).
+            for attempt in range(2):
+                try:
+                    stream = await _acompletion_tolerant(kwargs, self)
+                    async for chunk in stream:
+                        delta_obj = _obj_get(_obj_get(chunk, "choices", [{}])[0], "delta", {})
+                        # Accumulate reasoning_content (Grok, DeepSeek, etc.)
+                        # without yielding it as user-visible text. Replayed
+                        # on the next turn so DeepSeek doesn't 400.
+                        _rc = (
+                            _obj_get(delta_obj, "reasoning_content", None)
+                            or _obj_get(delta_obj, "thinking", None)
+                            or _obj_get(delta_obj, "reasoning", None)
+                        )
+                        if _rc:
+                            _reasoning_parts.append(str(_rc))
+                            continue
+                        delta = _obj_get(delta_obj, "content", "")
+                        if not delta:
+                            continue
+                        if isinstance(delta, str):
+                            yielded_any = True
+                            yield delta
+                            continue
+                        if isinstance(delta, list):
+                            text_parts: list[str] = []
+                            for part in delta:
+                                text = _obj_get(part, "text", "")
+                                if text:
+                                    text_parts.append(str(text))
+                            if text_parts:
+                                yielded_any = True
+                                yield "".join(text_parts)
+                            continue
+                        yielded_any = True
+                        yield str(delta)
+                    break
+                except Exception as stream_err:
+                    if (
+                        attempt == 0
+                        and not yielded_any
+                        and kwargs.get("tool_choice") is not None
+                        and _is_tool_choice_unsupported_error(str(stream_err).lower())
+                    ):
+                        self._tool_choice_unsupported = True
+                        kwargs.pop("tool_choice", None)
+                        _reasoning_parts.clear()
+                        log.warning(
+                            "Streaming model rejected tool_choice; retrying without it",
+                            model=kwargs.get("model"),
+                        )
+                        continue
+                    raise
             # Persist the accumulated reasoning so the caller (e.g.
             # ``stream()`` in the orchestration layer) can stash it
             # on the just-produced assistant message.
@@ -3438,8 +3484,28 @@ class LiteLLMProvider(LLMProvider):
             # Request usage in the final stream chunk.
             kwargs["stream_options"] = {"include_usage": True}
 
-            stream = await _acompletion_tolerant(kwargs, self)
-            collected = await self._collect_streaming_response(stream, on_chunk=on_chunk)
+            try:
+                stream = await _acompletion_tolerant(kwargs, self)
+                collected = await self._collect_streaming_response(stream, on_chunk=on_chunk)
+            except Exception as stream_err:
+                # A forced tool_choice a thinking-mode model rejects surfaces
+                # HERE — during stream iteration — not on the acompletion() call,
+                # so _acompletion_tolerant's own retry never sees it. The 400 is
+                # a pre-flight rejection (no content streamed yet, on_chunk not
+                # called), so dropping the constraint and retrying once is safe.
+                if not (
+                    kwargs.get("tool_choice") is not None
+                    and _is_tool_choice_unsupported_error(str(stream_err).lower())
+                ):
+                    raise
+                self._tool_choice_unsupported = True
+                kwargs.pop("tool_choice", None)
+                log.warning(
+                    "Streaming model rejected tool_choice; retrying without it",
+                    model=kwargs.get("model"),
+                )
+                stream = await _acompletion_tolerant(kwargs, self)
+                collected = await self._collect_streaming_response(stream, on_chunk=on_chunk)
 
             # Parse the collected dict into an LLMResponse (same as complete()).
             choices = _obj_get(collected, "choices", [{}])

--- a/tests/test_llm/test_tool_choice_selfheal.py
+++ b/tests/test_llm/test_tool_choice_selfheal.py
@@ -1,0 +1,159 @@
+"""A thinking/reasoning model served over an OpenAI-compatible endpoint 400s
+when the orchestration loop forces ``tool_choice="required"`` on a stall retry:
+"Thinking mode does not support this tool_choice". On the streaming paths that
+400 surfaces *during stream iteration* — not on the ``acompletion()`` call — so
+``_acompletion_tolerant``'s own retry never sees it and the turn crashed with
+"openai streaming callback failed". The streaming methods now catch that 400,
+drop the forced constraint, flag the provider, and retry once.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import captain_claw.llm as llm_mod
+from captain_claw.llm import (
+    LiteLLMProvider,
+    Message,
+    ToolDefinition,
+    _is_tool_choice_unsupported_error,
+)
+
+
+# --- Classifier -------------------------------------------------------------
+
+
+def test_tool_choice_unsupported_matches_the_server_message():
+    m = ("litellm.badrequesterror: openaiexception - thinking mode does not "
+         "support this tool_choice")
+    assert _is_tool_choice_unsupported_error(m)
+
+
+def test_tool_choice_unsupported_matches_not_allowed_phrasing():
+    assert _is_tool_choice_unsupported_error(
+        "tool_choice is not allowed when reasoning is enabled"
+    )
+
+
+def test_tool_choice_unsupported_ignores_unrelated_400s():
+    assert not _is_tool_choice_unsupported_error("invalid temperature value")
+    assert not _is_tool_choice_unsupported_error("context length exceeded")
+    # A support-related 400 that isn't about tool_choice must not match.
+    assert not _is_tool_choice_unsupported_error(
+        "this model does not support image inputs"
+    )
+
+
+# --- Streaming self-heal ----------------------------------------------------
+
+
+class _FakeBadRequest(Exception):
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+_TOOL_CHOICE_400 = _FakeBadRequest(
+    "litellm.BadRequestError: OpenAIException - Thinking mode does not support "
+    "this tool_choice"
+)
+
+
+async def _raising_stream(exc: Exception):
+    """Async iterator that raises on first consumption — a pre-flight 400 that
+    surfaces only when the stream is read (nothing streamed yet)."""
+    if False:  # make this an async generator
+        yield  # pragma: no cover
+    raise exc
+
+
+async def _content_stream():
+    yield {"choices": [{"delta": {"content": "hello"}, "finish_reason": None}]}
+    yield {
+        "choices": [{"delta": {}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+    }
+
+
+def _forcing_provider() -> LiteLLMProvider:
+    provider = LiteLLMProvider(provider="openai", model="deepseek-thinker", api_key="x")
+    # The orchestration loop's strongest lever: force a tool call this turn.
+    provider._tool_choice_override = "required"
+    return provider
+
+
+_TOOLS = [ToolDefinition(name="write", description="write a file", parameters={})]
+
+
+async def test_complete_with_callback_self_heals_tool_choice(monkeypatch):
+    provider = _forcing_provider()
+    calls = {"n": 0}
+
+    async def fake_tolerant(kwargs, prov=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # First attempt carries the forced constraint...
+            assert kwargs.get("tool_choice") == "required"
+            return _raising_stream(_TOOL_CHOICE_400)
+        # ...retry drops it.
+        assert "tool_choice" not in kwargs
+        return _content_stream()
+
+    monkeypatch.setattr(llm_mod, "_acompletion_tolerant", fake_tolerant)
+
+    seen: list[str] = []
+    resp = await provider.complete_with_callback(
+        [Message(role="user", content="hi")], tools=_TOOLS, on_chunk=seen.append
+    )
+
+    assert calls["n"] == 2
+    assert provider._tool_choice_unsupported is True
+    assert resp.content == "hello"
+    # No content was streamed on the failed attempt, so the callback fires once.
+    assert seen == ["hello"]
+
+
+async def test_complete_with_callback_does_not_retry_unrelated_stream_error(monkeypatch):
+    # An unrelated mid-stream error is NOT a tool_choice rejection, so the
+    # existing "preserve partial content" behavior stands: no retry, no
+    # provider flag flipped, and the collector returns what it had (empty here).
+    provider = _forcing_provider()
+    calls = {"n": 0}
+
+    async def fake_tolerant(kwargs, prov=None):
+        calls["n"] += 1
+        return _raising_stream(_FakeBadRequest("context length exceeded"))
+
+    monkeypatch.setattr(llm_mod, "_acompletion_tolerant", fake_tolerant)
+
+    resp = await provider.complete_with_callback(
+        [Message(role="user", content="hi")], tools=_TOOLS, on_chunk=lambda _c: None
+    )
+    assert calls["n"] == 1
+    assert resp.content == ""
+    assert getattr(provider, "_tool_choice_unsupported", False) is False
+
+
+async def test_complete_streaming_self_heals_tool_choice(monkeypatch):
+    provider = _forcing_provider()
+    calls = {"n": 0}
+
+    async def fake_tolerant(kwargs, prov=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert kwargs.get("tool_choice") == "required"
+            return _raising_stream(_TOOL_CHOICE_400)
+        assert "tool_choice" not in kwargs
+        return _content_stream()
+
+    monkeypatch.setattr(llm_mod, "_acompletion_tolerant", fake_tolerant)
+
+    chunks: list[str] = []
+    async for piece in provider.complete_streaming(
+        [Message(role="user", content="hi")], tools=_TOOLS
+    ):
+        chunks.append(piece)
+
+    assert calls["n"] == 2
+    assert provider._tool_choice_unsupported is True
+    assert "".join(chunks) == "hello"


### PR DESCRIPTION
## Problem

The WhatsApp agent crashed with:

> `Error: openai streaming callback failed: litellm.BadRequestError: OpenAIException - Thinking mode does not support this tool_choice`

A thinking/reasoning model served over an OpenAI-compatible endpoint returns a 400 when the orchestration loop forces `tool_choice="required"` on a stall retry.

## Root cause

Self-heal already existed (`_acompletion_tolerant` strips `tool_choice` and retries) **but only fires when the 400 is raised at the `acompletion()` call**. On the streaming paths the 400 surfaces *during stream consumption*, so that retry never saw it. Worse, `_collect_streaming_response` **swallowed every iteration error** and returned partial/empty content — turning the rejection into a silent empty reply.

## Fix (three layers, all in `captain_claw/llm/__init__.py`)

1. **New classifier** `_is_tool_choice_unsupported_error()` — matches the server message (`"tool_choice"` + `"support"`/`"not allowed"`), narrow enough not to catch unrelated 400s. `_acompletion_tolerant` now uses it too.
2. **`_collect_streaming_response`** re-raises this specific pre-flight 400 instead of swallowing it (nothing was streamed, so there's no partial content to preserve).
3. **`complete_with_callback` and `complete_streaming`** catch it, set `provider._tool_choice_unsupported = True`, drop the constraint, and **retry once** — only before any chunk was yielded, so there's no duplicated output. The flag makes the rest of the session skip forcing `tool_choice` on that model.

## Tests

New `tests/test_llm/test_tool_choice_selfheal.py` (6 tests): classifier matching, both streaming self-heal paths, and that unrelated iteration errors keep the existing preserve-partial-content behavior. All pass; adjacent LLM suites pass (the one unrelated `gpt-5-codex` factory failure is pre-existing on `main`).

## Deploy note

FD/agent backend code — the running service must be restarted to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)