### PR TITLE
fix(mcp): scope MCP server config per Flight Deck instance

### DIFF
--- a/captain_claw/flight_deck/mcp_storage.py
+++ b/captain_claw/flight_deck/mcp_storage.py
@@ -1,10 +1,13 @@
 """Persistent storage for Flight-Deck-managed MCP server configurations.
 
-Phase 1 keeps things deliberately simple: a flat JSON file under
-``~/.captain-claw-fd/mcp_servers.json`` containing a list of server
-records. Anything fancier (SQLite, encryption-at-rest, per-tenant
-scoping) is deferred until we have a clearer picture of what users
-actually want.
+A flat JSON file containing a list of server records. Its location is
+per-instance — see :func:`_storage_path` — so a host running several
+Flight Decks does not leak one deck's MCP servers into another; only the
+legacy ``~/.captain-claw-fd/mcp_servers.json`` fallback is shared, used
+when no isolation env (``CAPTAIN_CLAW_FD_MCP_PATH`` / ``CAPTAIN_CLAW_FD_HOME``
+/ ``FD_DATA_DIR``) is set. Anything fancier (SQLite, encryption-at-rest,
+per-tenant scoping within one deck) is deferred until we have a clearer
+picture of what users actually want.
 
 Schema (one element per configured server)::
 
@@ -58,10 +61,61 @@ _DEFAULT_PATH = _DEFAULT_DIR / "mcp_servers.json"
 
 
 def _storage_path() -> Path:
+    """Resolve this instance's MCP servers file.
+
+    Precedence (first match wins) so a host running several Flight Decks
+    isolates MCP config the same way it already isolates the rest of its
+    state — the shared legacy default was the source of cross-instance
+    leaks (one deck's servers showing up in another):
+
+    1. ``CAPTAIN_CLAW_FD_MCP_PATH`` — an explicit file, always wins.
+    2. ``CAPTAIN_CLAW_FD_HOME`` — the FD home dir that also holds
+       ``agent_secret`` / ``apps`` / ``app_data``; keep the file beside them.
+    3. ``FD_DATA_DIR`` — the general per-instance data dir (DB, plans, …).
+    4. the legacy shared ``~/.captain-claw-fd/mcp_servers.json``.
+
+    Only #4 is shared across instances; setting any of #1–#3 (as every
+    isolated deck already does for its data dir) gives this deck its own
+    MCP config, so a new install starts with no servers instead of
+    inheriting whatever another deck configured.
+    """
     override = os.environ.get("CAPTAIN_CLAW_FD_MCP_PATH", "").strip()
     if override:
         return Path(override).expanduser()
+    home = os.environ.get("CAPTAIN_CLAW_FD_HOME", "").strip()
+    if home:
+        return Path(home).expanduser().resolve() / "mcp_servers.json"
+    data_dir = os.environ.get("FD_DATA_DIR", "").strip()
+    if data_dir:
+        return Path(data_dir).expanduser().resolve() / "mcp_servers.json"
     return _DEFAULT_PATH
+
+
+# One-time migration hint: warn (once per resolved path) when an isolated
+# deck finds no MCP file of its own but the legacy shared one exists — so an
+# admin who *wants* those servers here knows to copy the file in, while a
+# deck that should stay clean (e.g. a kiosk) silently gets no servers.
+_migration_warned: set[str] = set()
+
+
+def _maybe_warn_legacy_migration(path: Path) -> None:
+    if path == _DEFAULT_PATH:
+        return
+    key = str(path)
+    if key in _migration_warned:
+        return
+    _migration_warned.add(key)
+    try:
+        if not path.exists() and _DEFAULT_PATH.exists():
+            log.info(
+                "No MCP servers file at %s; the legacy shared file %s exists but "
+                "is no longer read by an isolated instance. Copy it here if this "
+                "deck should keep those servers, or leave it for a clean deck.",
+                path,
+                _DEFAULT_PATH,
+            )
+    except Exception:
+        pass
 
 
 _write_lock = asyncio.Lock()
@@ -147,6 +201,7 @@ def _public_view(record: dict[str, Any]) -> dict[str, Any]:
 def load_servers() -> list[dict[str, Any]]:
     path = _storage_path()
     if not path.exists():
+        _maybe_warn_legacy_migration(path)
         return []
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_flight_deck/test_mcp.py
+++ b/tests/test_flight_deck/test_mcp.py
@@ -138,6 +138,39 @@ class FakeMCPServer:
 # ── storage tests ───────────────────────────────────────────────────
 
 
+def test_storage_path_is_per_instance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The servers file follows the instance's isolation env, so several
+    Flight Decks on one host don't share (and leak) MCP config.
+
+    Precedence: CAPTAIN_CLAW_FD_MCP_PATH > CAPTAIN_CLAW_FD_HOME >
+    FD_DATA_DIR > legacy ~/.captain-claw-fd.
+    """
+    explicit = tmp_path / "explicit.json"
+    home = tmp_path / "home"
+    data = tmp_path / "data"
+
+    # Explicit file wins over everything.
+    monkeypatch.setenv("CAPTAIN_CLAW_FD_MCP_PATH", str(explicit))
+    monkeypatch.setenv("CAPTAIN_CLAW_FD_HOME", str(home))
+    monkeypatch.setenv("FD_DATA_DIR", str(data))
+    assert mcp_storage._storage_path() == explicit  # noqa: SLF001
+
+    # FD_HOME beats FD_DATA_DIR (mcp_servers.json sits beside agent_secret/apps).
+    monkeypatch.delenv("CAPTAIN_CLAW_FD_MCP_PATH", raising=False)
+    assert mcp_storage._storage_path() == home.resolve() / "mcp_servers.json"  # noqa: SLF001
+
+    # FD_DATA_DIR is used when FD_HOME is unset — this is what the user's
+    # isolated decks set, so each gets its own file.
+    monkeypatch.delenv("CAPTAIN_CLAW_FD_HOME", raising=False)
+    assert mcp_storage._storage_path() == data.resolve() / "mcp_servers.json"  # noqa: SLF001
+
+    # With no isolation env, fall back to the shared legacy default.
+    monkeypatch.delenv("FD_DATA_DIR", raising=False)
+    assert mcp_storage._storage_path() == mcp_storage._DEFAULT_PATH  # noqa: SLF001
+
+
 @pytest.mark.asyncio
 async def test_storage_round_trip_with_masking(_isolate_storage: Path) -> None:
     assert mcp_storage.load_servers() == []


### PR DESCRIPTION
## Problem

On a host running several Flight Decks, all instances share a single `~/.captain-claw-fd/mcp_servers.json`. A newly installed deck (e.g. the locked `--simple-chat` kiosk) therefore inherits MCP servers configured by *another* deck — observed as a kiosk agent reaching `mcp_fric_*` tools it should never have. Every other FD store already isolates by `FD_DATA_DIR`; MCP storage was the lone outlier.

## Fix

`mcp_storage._storage_path()` now resolves per instance, first match wins:

1. `CAPTAIN_CLAW_FD_MCP_PATH` — explicit file
2. `CAPTAIN_CLAW_FD_HOME/mcp_servers.json` — beside `agent_secret` / `apps`
3. `FD_DATA_DIR/mcp_servers.json` — the general per-instance data dir
4. `~/.captain-claw-fd/mcp_servers.json` — legacy shared fallback

Only #4 is shared, so any isolated deck starts empty instead of inheriting another's servers. When an isolated deck finds no file of its own but the legacy shared file exists, `load_servers()` logs a one-time migration hint.

## Migration (important)

Decks that isolate via `FD_DATA_DIR`/`FD_HOME` **and should keep their MCP servers** must copy the legacy file into their data/home dir once, e.g.:

```
cp ~/.captain-claw-fd/mcp_servers.json "$FD_DATA_DIR/mcp_servers.json"
```

A clean deck (the kiosk) leaves it and gets nothing.

## Verification

- Runtime: no-isolation env resolves to the shared file (sees `fric`); a kiosk-shaped env with its own `FD_DATA_DIR` resolves to its own file → `[]` + the migration hint.
- New precedence unit test passes. The 7 pre-existing manager/route handshake failures in this environment are unchanged (confirmed by stash/compare) — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)