### PR TITLE
fix(fd): isolate app state + agent_secret per instance (honor FD_DATA_DIR)

### DIFF
--- a/captain_claw/flight_deck/agent_secret.py
+++ b/captain_claw/flight_deck/agent_secret.py
@@ -71,14 +71,24 @@ def _real_user_home() -> Path:
 
 
 def _secret_path() -> Path:
-    """Path to the secret file.
+    """Path to the secret file — per Flight Deck instance.
 
-    Always under the real user's home so FD and agents (which may
-    have different ``$HOME`` overrides) all read the same file.
-    The directory name matches ``app_runtime._fd_home``'s default
-    so an unsandboxed FD writes it next to its other state.
+    Precedence (see :mod:`fd_home`): ``CAPTAIN_CLAW_FD_HOME`` >
+    ``FD_DATA_DIR`` > the legacy ``<passwd-home>/.captain-claw-fd``.
+    Several decks on one host each isolate via their own ``FD_DATA_DIR``
+    (or FD home), so a deck no longer authenticates against another
+    deck's secret; the file still sits beside that deck's other state
+    (``app_runtime._fd_home`` uses the same resolution).
+
+    The legacy fallback stays anchored to the *passwd* home, not
+    ``$HOME``: FD spawns agents with ``HOME`` redirected to a sandbox,
+    and in the unisolated single-deck case FD and its in-process agents
+    must still converge on one file. When an isolation env is set both
+    FD and the local agents it spawns inherit the same value (agents get
+    FD's full environment), so they converge there too.
     """
-    return _real_user_home() / ".captain-claw-fd" / _SECRET_FILE_NAME
+    from captain_claw.flight_deck.fd_home import fd_home
+    return fd_home(_real_user_home() / ".captain-claw-fd") / _SECRET_FILE_NAME
 
 
 def _read_file() -> str:

--- a/captain_claw/flight_deck/app_entities.py
+++ b/captain_claw/flight_deck/app_entities.py
@@ -59,8 +59,9 @@ def _now() -> str:
 
 
 def _default_base() -> Path:
-    base = os.environ.get("CAPTAIN_CLAW_FD_HOME") or os.path.expanduser("~/.captain-claw-fd")
-    return Path(base) / "app_data"
+    # Per-instance: CAPTAIN_CLAW_FD_HOME > FD_DATA_DIR > legacy ~/.captain-claw-fd.
+    from captain_claw.flight_deck.fd_home import fd_home
+    return fd_home(Path(os.path.expanduser("~/.captain-claw-fd"))) / "app_data"
 
 
 # ── local filesystem implementation ──────────────────────────────────

--- a/captain_claw/flight_deck/app_files.py
+++ b/captain_claw/flight_deck/app_files.py
@@ -74,8 +74,9 @@ def _safe_id(agent_id: str) -> str:
 
 
 def _default_base() -> Path:
-    base = os.environ.get("CAPTAIN_CLAW_FD_HOME") or os.path.expanduser("~/.captain-claw-fd")
-    return Path(base) / "app_files"
+    # Per-instance: CAPTAIN_CLAW_FD_HOME > FD_DATA_DIR > legacy ~/.captain-claw-fd.
+    from captain_claw.flight_deck.fd_home import fd_home
+    return fd_home(Path(os.path.expanduser("~/.captain-claw-fd"))) / "app_files"
 
 
 class LocalFileStore:

--- a/captain_claw/flight_deck/app_manifests.py
+++ b/captain_claw/flight_deck/app_manifests.py
@@ -31,8 +31,9 @@ from pydantic import BaseModel, Field, field_validator
 
 
 def _manifests_dir() -> Path:
-    base = os.environ.get("CAPTAIN_CLAW_FD_HOME") or os.path.expanduser("~/.captain-claw-fd")
-    p = Path(base) / "app_manifests"
+    # Per-instance: CAPTAIN_CLAW_FD_HOME > FD_DATA_DIR > legacy ~/.captain-claw-fd.
+    from captain_claw.flight_deck.fd_home import fd_home
+    p = fd_home(Path(os.path.expanduser("~/.captain-claw-fd"))) / "app_manifests"
     p.mkdir(parents=True, exist_ok=True)
     return p
 

--- a/captain_claw/flight_deck/app_runtime.py
+++ b/captain_claw/flight_deck/app_runtime.py
@@ -49,8 +49,9 @@ log = logging.getLogger(__name__)
 
 
 def _fd_home() -> Path:
-    base = os.environ.get("CAPTAIN_CLAW_FD_HOME") or os.path.expanduser("~/.captain-claw-fd")
-    return Path(base)
+    # Per-instance: CAPTAIN_CLAW_FD_HOME > FD_DATA_DIR > legacy ~/.captain-claw-fd.
+    from captain_claw.flight_deck.fd_home import fd_home
+    return fd_home(Path(os.path.expanduser("~/.captain-claw-fd")))
 
 
 def apps_root() -> Path:
@@ -571,7 +572,9 @@ def _build_subprocess_env(*, slug: str) -> dict[str, str]:
     """
     keep = {
         "PATH", "PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV",
-        "CAPTAIN_CLAW_FD_HOME",
+        # Both FD-home isolation envs, so a subprocess that resolves
+        # ``fd_home()`` lands on the same tree this FD uses.
+        "CAPTAIN_CLAW_FD_HOME", "FD_DATA_DIR",
         "LANG", "LC_ALL", "LC_CTYPE",
         "HOME",
         # Some libraries (httpx, anyio) refuse to start without TZ or TMPDIR.

--- a/captain_claw/flight_deck/fd_home.py
+++ b/captain_claw/flight_deck/fd_home.py
@@ -1,0 +1,46 @@
+"""Resolve the Flight Deck home directory — per instance.
+
+Several state stores (code-apps under ``apps/``, their ``app_data/`` /
+``app_files/`` / ``app_manifests/``, and the ``agent_secret`` file) used
+to live only under ``CAPTAIN_CLAW_FD_HOME`` or the shared
+``~/.captain-claw-fd`` default. On a host running several Flight Decks
+that meant one deck's app data / secret leaked into another. Every other
+FD store already isolates by ``FD_DATA_DIR``; this helper lets those
+stores do the same, with one precedence defined in one place.
+
+Precedence (first match wins):
+
+1. ``CAPTAIN_CLAW_FD_HOME`` — an explicit FD home override, always wins.
+2. ``FD_DATA_DIR`` — the general per-instance data dir the DB, plans,
+   events, scheduler and MCP config already sit under. State lands flat
+   inside it (``<data_dir>/apps``, ``<data_dir>/agent_secret``, …), the
+   same way :mod:`mcp_storage` writes ``<data_dir>/mcp_servers.json``.
+3. the caller's ``legacy`` fallback — the shared default used when no
+   isolation env is set (single-instance installs, unchanged behaviour).
+
+Only #3 is shared across instances, so a deck that isolates via
+``FD_DATA_DIR`` (or ``CAPTAIN_CLAW_FD_HOME``) starts with its own empty
+tree instead of inheriting another deck's.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def fd_home(legacy: Path) -> Path:
+    """Return the base dir for per-instance FD state (see module docstring).
+
+    ``legacy`` is the shared fallback to use when neither isolation env is
+    set; callers pass their own so the pre-existing default is preserved
+    exactly (``app_*`` anchor to ``$HOME``; ``agent_secret`` anchors to the
+    passwd home so a sandboxed-``HOME`` agent still converges).
+    """
+    home = os.environ.get("CAPTAIN_CLAW_FD_HOME", "").strip()
+    if home:
+        return Path(home).expanduser().resolve()
+    data_dir = os.environ.get("FD_DATA_DIR", "").strip()
+    if data_dir:
+        return Path(data_dir).expanduser().resolve()
+    return legacy

--- a/tests/test_flight_deck/test_fd_home_isolation.py
+++ b/tests/test_flight_deck/test_fd_home_isolation.py
@@ -1,0 +1,94 @@
+"""Per-instance isolation of Flight Deck home-anchored state.
+
+Several Flight Decks on one host must not share their code-app state
+(``apps`` / ``app_data`` / ``app_files`` / ``app_manifests``) or their
+``agent_secret``. All of these resolve through :func:`fd_home.fd_home`
+with the precedence CAPTAIN_CLAW_FD_HOME > FD_DATA_DIR > legacy.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from captain_claw.flight_deck import (
+    agent_secret,
+    app_entities,
+    app_files,
+    app_manifests,
+    app_runtime,
+)
+from captain_claw.flight_deck.fd_home import fd_home
+
+
+def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k in ("CAPTAIN_CLAW_FD_HOME", "FD_DATA_DIR"):
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_fd_home_precedence(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    legacy = tmp_path / "legacy"
+    home = tmp_path / "home"
+    data = tmp_path / "data"
+
+    # FD_HOME wins over FD_DATA_DIR and legacy.
+    _clear(monkeypatch)
+    monkeypatch.setenv("CAPTAIN_CLAW_FD_HOME", str(home))
+    monkeypatch.setenv("FD_DATA_DIR", str(data))
+    assert fd_home(legacy) == home.resolve()
+
+    # FD_DATA_DIR when FD_HOME unset.
+    monkeypatch.delenv("CAPTAIN_CLAW_FD_HOME", raising=False)
+    assert fd_home(legacy) == data.resolve()
+
+    # Legacy fallback when neither is set.
+    monkeypatch.delenv("FD_DATA_DIR", raising=False)
+    assert fd_home(legacy) == legacy
+
+
+def test_app_state_dirs_follow_data_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """apps / app_data / app_files / app_manifests land under FD_DATA_DIR."""
+    _clear(monkeypatch)
+    data = tmp_path / "deckA"
+    monkeypatch.setenv("FD_DATA_DIR", str(data))
+
+    assert app_runtime.apps_root() == data.resolve() / "apps"
+    assert app_files._default_base() == data.resolve() / "app_files"
+    assert app_manifests._manifests_dir() == data.resolve() / "app_manifests"
+    assert app_entities._default_base() == data.resolve() / "app_data"
+
+
+def test_two_decks_get_separate_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The whole point: deck A and deck B never resolve to the same dir."""
+    a, b = tmp_path / "A", tmp_path / "B"
+    _clear(monkeypatch)
+
+    monkeypatch.setenv("FD_DATA_DIR", str(a))
+    a_apps = app_runtime.apps_root()
+    a_secret = agent_secret._secret_path()
+
+    monkeypatch.setenv("FD_DATA_DIR", str(b))
+    b_apps = app_runtime.apps_root()
+    b_secret = agent_secret._secret_path()
+
+    assert a_apps != b_apps
+    assert a_secret != b_secret
+    assert a_secret == a.resolve() / "agent_secret"
+    assert b_secret == b.resolve() / "agent_secret"
+
+
+def test_agent_secret_legacy_uses_passwd_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no isolation env, the secret stays anchored to the passwd home
+    (not $HOME) so a sandboxed-HOME agent still converges with FD."""
+    _clear(monkeypatch)
+    monkeypatch.setenv("HOME", "/tmp/some-sandbox-home")  # noqa: S108
+    expected = agent_secret._real_user_home() / ".captain-claw-fd" / "agent_secret"
+    assert agent_secret._secret_path() == expected


### PR DESCRIPTION
## What

Follow-up to the MCP isolation fix (#17). The remaining FD-home-anchored state — code-apps under `apps/`, their `app_data/` / `app_files/` / `app_manifests/`, and the `agent_secret` file — lived only under `CAPTAIN_CLAW_FD_HOME` or the shared `~/.captain-claw-fd` default. On a host running several Flight Decks (each isolating via `FD_DATA_DIR`), that meant one deck's **app data** leaked into another and all decks shared **one agent→FD auth secret**.

## Change

New `captain_claw/flight_deck/fd_home.py` centralises resolution, first match wins:

1. `CAPTAIN_CLAW_FD_HOME` — explicit FD home
2. `FD_DATA_DIR` — the per-instance data dir the DB / plans / MCP config already use
3. legacy shared `~/.captain-claw-fd` (single-instance behaviour, unchanged)

Wired into `app_runtime._fd_home`, the `app_files` / `app_manifests` / `app_entities` base dirs, and `agent_secret._secret_path`. `FD_DATA_DIR` is also added to the code-app subprocess env allowlist so a subprocess resolving `fd_home()` converges with its FD.

## Why it's safe

- The app SDK subprocess reaches FD over HTTP (`FD_INTERNAL_URL`) — it never resolves these dirs locally, so they're FD-only.
- Agents read the shared secret from their **env** (`FD_AGENT_SHARED_SECRET`); only FD reads the secret file. Relocating it per-instance doesn't change how agents authenticate. `agent_secret`'s legacy fallback keeps the passwd-home anchor so a sandboxed-`HOME` agent still converges when no isolation env is set.

## Verification

- New tests: `fd_home` precedence, app dirs follow `FD_DATA_DIR`, two decks get separate state, legacy secret stays passwd-anchored. All pass.
- Runtime: deck A vs kiosk deck resolve all five stores under their own `FD_DATA_DIR`; legacy path unchanged.
- The 7 pre-existing mcp manager/route handshake failures in this environment are unchanged (no regression).

## Operational note

Existing decks that switch to `FD_DATA_DIR` get a fresh per-deck `agent_secret` on restart. In the auto-managed case agents don't carry the secret in-env, so this is low-impact; if you set `FD_AGENT_SHARED_SECRET` explicitly in FD's env it still wins. To keep an old value, copy `~/.captain-claw-fd/agent_secret` into that deck's data dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)